### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
Build is failing since we don't support older Pythons anymore.